### PR TITLE
Fix for compilation issue due to compiler directive typo

### DIFF
--- a/AlpacaIT.DynamicLighting/Scripts/Core/DynamicLightManager.ShadowCamera.cs
+++ b/AlpacaIT.DynamicLighting/Scripts/Core/DynamicLightManager.ShadowCamera.cs
@@ -48,7 +48,7 @@ namespace AlpacaIT.DynamicLighting
         {
             shadowCameraDepthShader = DynamicLightingResources.Instance.shadowCameraDepthShader;
 
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2021_3_OR_GREATER
             shadowCameraRenderTextureDescriptor = new RenderTextureDescriptor(shadowCameraResolution, shadowCameraResolution, RenderTextureFormat.RHalf, 16, 0, RenderTextureReadWrite.Linear);
 #else
             shadowCameraRenderTextureDescriptor = new RenderTextureDescriptor(shadowCameraResolution, shadowCameraResolution, RenderTextureFormat.RHalf, 16, 0);


### PR DESCRIPTION
This PR fixes a small typo in `DynamicLightingManager.ShadowCamera`, where the plugin fails to compile due to a typo in a compiler directive.